### PR TITLE
Use HTTPS with bscscan

### DIFF
--- a/src.ts/bscscan-provider.ts
+++ b/src.ts/bscscan-provider.ts
@@ -28,9 +28,9 @@ export class BscscanProvider extends ethers.providers.EtherscanProvider {
     getBaseUrl(): string {
         switch (this.network ? this.network.name: "invalid") {
             case "bsc-mainnet":
-                return "http:/\/api.bscscan.com";
+                return "https:/\/api.bscscan.com";
             case "bsc-testnet":
-                return "http:/\/api-testnet.bscscan.com";
+                return "https:/\/api-testnet.bscscan.com";
         }
 
         return logger.throwArgumentError("unsupported network", "network", this.network);


### PR DESCRIPTION
Use HTTPS with [bscscan](https://testnet.bscscan.com/apis#stats)

Test with [default code](https://api-testnet.bscscan.com/api?module=stats&action=bnbsupply&apikey=EVTS3CU31AATZV72YQ55TPGXGMVIFUQ9M9):

```json
{
  "status": "1",
  "message": "OK",
  "result": "4743307367795260000000000"
}
```